### PR TITLE
Update required SLF4J bundle to Kepler/Luna version

### DIFF
--- a/ch.qos.logback.beagle/META-INF/MANIFEST.MF
+++ b/ch.qos.logback.beagle/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.ide;bundle-version="3.7.0",
  ch.qos.logback.classic;bundle-version="1.0.7",
  ch.qos.logback.core;bundle-version="1.0.7",
- slf4j.api;bundle-version="1.6.6"
+ org.slf4j.api;bundle-version="1.7.2"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: ch.qos.logback.beagle,


### PR DESCRIPTION
Eclipse Kepler/Luna is using `org.slf4j.api-1.7.2` instead of `slf4j.api-1.6.6`
